### PR TITLE
add schema for exposure and sensitivity

### DIFF
--- a/proposals/physical-cameras/README.md
+++ b/proposals/physical-cameras/README.md
@@ -314,4 +314,96 @@ class PhysicalCameraLensModelPinhole "PhysicalCameraLensModelPinhole" (
         doc = '''squeeze'''
     )
 }
+
+class PhysicalCameraExposure "PhysicalCameraExposure" (
+    doc = """
+    Describes the exposure settings common to still and cinema cameras.
+
+    These settings are used to scale the brightness of the illumination incident
+    on the camera system. The scaling factor, S, is computed as:
+       S = sensitivity_compensation * iso * 2^exposure_compensation / (100 * shutterspeed * fnumber^2)
+    """
+    inherits = </APISchemaBase>
+    customData = {
+        token apiSchemaType = "singleApply"
+    }
+)
+{
+    float physcam:exposure:fnumber = 1.0 (
+        doc = """The lens aperture f-number"""
+    )
+
+    float physcam:exposure:iso = 100 (
+        doc = """The speed rating of the sensor or film"""
+    )
+
+    float physcam:exposure:shutterspeed = 1.0 (
+        doc = """The exposure time as fractions of a second, e.g. a value of 
+        100 corresponds to 1/100s
+        """
+    )
+
+    float physcam:exposure:exposure_compensation = 0.0 (
+        doc = """Adjusts the brightness of the image by a factor of 
+        2^exposure_compensation
+        """
+    )
+
+    float physcam:exposure:sensitivity_compensation = 1.0 (
+        doc = """Scalar multiplier that represents the overall scaling of incident
+        exposure by the camera system, including loss by the lens and scaling
+        by the camera ISP
+        """       
+    )
+}
+
+class PhysicalCameraSensorSensitivity "PhysicalCameraSensorSensitivity" (
+    doc = """
+    Describes camera's native colour space in terms of the colour matching functions
+    for the red, green and blue primaries, and a matrix for transforming from the resulting
+    camera RGB value to CIE XYZ. For more information on the use of these values see
+    https://github.com/wetadigital/physlight/blob/main/examples/physlight_camera_model.ipynb
+    """
+    inherits = </APISchemaBase>
+    customData = {
+        token apiSchemaType = "singleApply"
+    }
+)
+{
+    float2[] physcam:sensitivity:red = [...default to XYZ X_bar] (
+        doc = """Colour matching function for calculating the output of the camera
+        RGB red value given an incident spectral exposure, by convolution. The CMF
+        is represented as a list of [wavelength, value] pairs, where wavelength is
+        in nanometers. Values at intermediate wavelengths are calculated by linear
+        interpolation, and values at wavelengths not within the domain of the given
+        samples are calculated by linear extrapolation.
+        """
+    )
+
+    float2[] physcam:sensitivity:green = [...default to XYZ Y_bar] (
+        doc = """Colour matching function for calculating the output of the camera
+        RGB green value given an incident spectral exposure, by convolution. The CMF
+        is represented as a list of [wavelength, value] pairs, where wavelength is
+        in nanometers. Values at intermediate wavelengths are calculated by linear
+        interpolation, and values at wavelengths not within the domain of the given
+        samples are calculated by linear extrapolation.
+        """
+    )
+
+    float2[] physcam:sensitivity:blue = [...default to XYZ Z_bar] (
+        doc = """Colour matching function for calculating the output of the camera
+        RGB blue value given an incident spectral exposure, by convolution. The CMF
+        is represented as a list of [wavelength, value] pairs, where wavelength is
+        in nanometers. Values at intermediate wavelengths are calculated by linear
+        interpolation, and values at wavelengths not within the domain of the given
+        samples are calculated by linear extrapolation.
+        """
+    )
+
+    matrix3d physcam:sensitivity:cam_to_xyz = [1 0 0 0 1 0 0 0 1] (
+        doc = """3x3 matrix representing the transformation from Camera RGB to 
+        CIE XYZ
+        """
+    )
+}
 ```


### PR DESCRIPTION
This adds the PhysicalCameraExposure and PhysicalCameraSensorSensitivity schema. Both are single-apply schema intended to be applied to a PhysicalCamera or UsdGeomCamera. Exposure adds iso, shutter speed etc, and SensorSensitivity adds spectral sensitivity curves in the spirit of Wetas physLight

### Description of Proposal

<!--
Please put a brief synopsis of the proposal here

The proposal itself should be in the PR as a markdown file to aid annotation and feedback.
-->

### Supporting Materials

<!--
Put screenshots or other summary information here
-->

### Contributing

<!--
Please review the  [Contributing](https://graphics.pixar.com/usd/release/contributing_to_usd.html) page in the
documentation for the Supplemental Terms that apply to this repository.
Place an X in the box when you have reviewed and agree to the Supplemental Terms.
-->
- [x] I agree to and accept the [Supplemental Terms](https://graphics.pixar.com/usd/release/contributing_supplemental.html).
